### PR TITLE
Added proper content types which is now required by SkillMEx

### DIFF
--- a/registration/src/main/java/registration/ModuleRegistration.java
+++ b/registration/src/main/java/registration/ModuleRegistration.java
@@ -14,8 +14,6 @@ public class ModuleRegistration extends RegistrationMethods {
 
 	@Override
 	public void register(String requestBody, Object object, ModuleRegistry moduleRegistry) {
-		// TODO Auto-generated method stub
-
 		// module is registered to every available OPS
 		for (OpsDescription ops : moduleRegistry.getOpsDescriptionList()) {
 			logger.info("Registering Module " + object.getClass().getAnnotation(Module.class).moduleIri()
@@ -23,7 +21,7 @@ public class ModuleRegistration extends RegistrationMethods {
 
 			String location = ops.getBasePath() + ops.getModuleEndpoint();
 
-			int responseStatusCode = opsRequest(ops, "POST", location, requestBody, "text/plain");
+			int responseStatusCode = opsRequest(ops, "POST", location, requestBody, "application/x-turtle; charset=UTF-8");
 
 			// if module successfully registered to OPS, it is added to module list of this
 			// OPS

--- a/registration/src/main/java/registration/RegistrationMethods.java
+++ b/registration/src/main/java/registration/RegistrationMethods.java
@@ -89,7 +89,7 @@ public abstract class RegistrationMethods {
 	 * @param location       path of OPS
 	 * @param requestBody    rdf description which is send in the body of the
 	 *                       request
-	 * @param contentType    if its text/plain or application/json etc.
+	 * @param contentType    Content-Type header (e.g. application/rdf-xml or application/x-turtle)
 	 * @return status code of the received response
 	 */
 	public int opsRequest(OpsDescription opsDescription, String requestType, String location, String requestBody,

--- a/registration/src/main/java/registration/SkillRegistration.java
+++ b/registration/src/main/java/registration/SkillRegistration.java
@@ -33,7 +33,7 @@ public class SkillRegistration extends RegistrationMethods {
 			String location = ops.getBasePath() + ops.getModuleEndpoint() + "/" + encodeValue(moduleIri)
 					+ ops.getSkillEndpoint();
 
-			int responseStatusCode = opsRequest(ops, "POST", location, requestBody, "text/plain");
+			int responseStatusCode = opsRequest(ops, "POST", location, requestBody, "application/x-turtle; charset=UTF-8");
 
 			if (responseStatusCode == 201) {
 				logger.info("Skill " + object.getClass().getAnnotation(Skill.class).skillIri() + " registered to "


### PR DESCRIPTION
Proper content type is required by SkillMEx so that differnt rdf encondings (turtle, XML, ...) can be used. This sets content types correctly